### PR TITLE
Anchor teams

### DIFF
--- a/soh/soh/Enhancements/enhancementTypes.h
+++ b/soh/soh/Enhancements/enhancementTypes.h
@@ -78,4 +78,11 @@ typedef enum {
     DEKU_STICK_UNBREAKABLE_AND_ALWAYS_ON_FIRE,
 } DekuStickType;
 
+typedef enum {
+    ICE_TRAP_TARGETS_TEAM_ONLY,
+    ICE_TRAP_TARGETS_SELF_ONLY,
+    ICE_TRAP_TARGETS_ENEMIES_ONLY,
+    ICE_TRAP_TARGETS_ALL,
+} IceTrapTargets;
+
 #endif

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Anchor.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Anchor.cpp
@@ -463,6 +463,21 @@ void GameInteractorAnchor::HandleRemoteJson(nlohmann::json payload) {
         GetItemEntry getItemEntry = ItemTableManager::Instance->RetrieveItemEntry(modId, getItemId);
 
         if (!from_teammate) {
+            if (getItemId == 141) {
+                auto effect = new GameInteractionEffect::GiveItem();
+                effect->parameters[0] = modId;
+                effect->parameters[1] = getItemId;
+                CVarSetInteger("gFromGI", 1);
+                receivedItems.push_back({ modId, getItemId });
+                if (effect->Apply() == Possible) {
+                    if (getItemEntry.getItemCategory != ITEM_CATEGORY_JUNK) {
+                        if (getItemEntry.modIndex == MOD_NONE) {
+                        } else if (getItemEntry.modIndex == MOD_RANDOMIZER) {
+                        }
+                    }
+                }
+                CVarClear("gFromGI");
+            }
             if (CVarGetInteger("gBroadcastItemsToAll", 0) != 0) {
                 // Broadcast that the item was found, but don't receive item.
                 if (getItemEntry.getItemCategory != ITEM_CATEGORY_JUNK) {
@@ -483,6 +498,8 @@ void GameInteractorAnchor::HandleRemoteJson(nlohmann::json payload) {
                     }
                 }
             }
+            return;
+        }  else if (getItemId == 141) {
             return;
         }
         auto effect = new GameInteractionEffect::GiveItem();

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Anchor.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Anchor.cpp
@@ -328,6 +328,7 @@ void Anchor_PushSettingsToRemote() {
     payload["type"] = "PUSH_ANCHOR_SETTINGS";
     payload["broadcastItemsToAll"] = CVarGetInteger("gBroadcastItemsToAll", 0);
     payload["teleportRupeeCost"] = CVarGetInteger("gTeleportRupeeCost", 0);
+    payload["pvpDamageMul"] = CVarGetInteger("gPvpDamageMul", 0);
 
     GameInteractorAnchor::Instance->TransmitJsonToRemote(payload);
 }
@@ -346,6 +347,7 @@ void Anchor_CopySettingsFromRemote(nlohmann::json payload) {
 
     CVarSetInteger("gBroadcastItemsToAll", payload["broadcastItemsToAll"].get<int32_t>());
     CVarSetInteger("gTeleportRupeeCost", payload["teleportRupeeCost"].get<int32_t>());
+    CVarSetInteger("gPvpDamageMul", payload["pvpDamageMul"].get<int32_t>());
 
     settingsCopied = true;
     Anchor_DisplayMessage({ .message = "Settings copied from remote." });
@@ -405,6 +407,21 @@ void GameInteractorAnchor::TransmitJsonToRemote(nlohmann::json payload) {
 
 void Anchor_ParseSaveStateFromRemote(nlohmann::json payload);
 void Anchor_PushSaveStateToRemote();
+
+int GetPvpDamageMultiplier() {
+    int32_t damageOption = CVarGetInteger("gPvpDamageMul", 0);
+    switch (damageOption) {
+        case 0: return 1;
+        case 1: return 2;
+        case 2: return 4;
+        case 3: return 8;
+        case 4: return 16;
+        case 5: return 32;
+        case 6: return 64;
+        case 7: return 128;
+        case 8: return 256;
+    }
+}
 
 void GameInteractorAnchor::HandleRemoteJson(nlohmann::json payload) {
     if (!payload.contains("type")) {
@@ -537,7 +554,7 @@ void GameInteractorAnchor::HandleRemoteJson(nlohmann::json payload) {
             !Player_InBlockingCsMode(gPlayState, GET_PLAYER(gPlayState))) {
             if (payload["damageEffect"] == PUPPET_DMGEFF_NORMAL) {
                 u8 damage = payload["damageValue"];
-                Player_InflictDamage(gPlayState, damage * -4);
+                Player_InflictDamage(gPlayState, damage * GetPvpDamageMultiplier() * -4);
                 func_80837C0C(gPlayState, GET_PLAYER(gPlayState), 0, 0, 0, 0, 0);
                 GET_PLAYER(gPlayState)->invincibilityTimer = 18;
                 GET_PLAYER(gPlayState)->actor.freezeTimer = 0;

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Anchor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Anchor.h
@@ -14,6 +14,7 @@ typedef struct {
     std::string clientVersion;
     std::string name;
     Color_RGB8 color;
+    std::string team;
     uint32_t seed;
     uint8_t fileNum;
     bool gameComplete;

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Anchor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Anchor.h
@@ -73,6 +73,15 @@ class AnchorLogWindow : public LUS::GuiWindow {
     void UpdateElement() override;
 };
 
+class AnchorTrapWindow : public LUS::GuiWindow {
+  public:
+    using GuiWindow::GuiWindow;
+
+    void InitElement() override {};
+    void DrawElement() override;
+    void UpdateElement() override {};
+};
+
 #endif
 #endif
 

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -898,7 +898,11 @@ std::vector<AltTrapType> getEnabledAddTraps () {
         }
     }
     if (enabledAddTraps.size() == 0) {
-        enabledAddTraps.push_back(ADD_ICE_TRAP);
+        if (CVarGetInteger("gIceTrapTargets", ICE_TRAP_TARGETS_SELF_ONLY) == ICE_TRAP_TARGETS_ENEMIES_ONLY) {
+            // We don't target ourselves, so leave enabledAddTraps empty.
+        } else {
+            enabledAddTraps.push_back(ADD_ICE_TRAP);
+        }
     }
     return enabledAddTraps;
 };
@@ -910,6 +914,10 @@ void RegisterAltTrapTypes() {
 
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnItemReceive>([](GetItemEntry itemEntry) {
         if (!CVarGetInteger("gAddTraps.enabled", 0) || itemEntry.modIndex != MOD_RANDOMIZER || itemEntry.getItemId != RG_ICE_TRAP) {
+            return;
+        }
+        if (getEnabledAddTraps().empty()) {
+            Audio_PlaySoundGeneral(NA_SE_PL_ICE_BROKEN, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
             return;
         }
         roll = RandomElement(getEnabledAddTraps());

--- a/soh/soh/SohGui.cpp
+++ b/soh/soh/SohGui.cpp
@@ -131,6 +131,7 @@ namespace SohGui {
 #ifdef ENABLE_REMOTE_CONTROL
     std::shared_ptr<AnchorPlayerLocationWindow> mAnchorPlayerLocationWindow;
     std::shared_ptr<AnchorLogWindow> mAnchorLogWindow;
+    std::shared_ptr<AnchorTrapWindow> mAnchorTrapWindow;
 #endif
 
     void SetupGuiElements() {
@@ -197,6 +198,8 @@ namespace SohGui {
         gui->AddGuiWindow(mAnchorPlayerLocationWindow);
         mAnchorLogWindow = std::make_shared<AnchorLogWindow>("gRemote.AnchorLogWindow", "Anchor Log");
         gui->AddGuiWindow(mAnchorLogWindow);
+        mAnchorTrapWindow = std::make_shared<AnchorTrapWindow>("gRemote.AnchorTrapWindow", "Anchor Trap Window");
+        gui->AddGuiWindow(mAnchorTrapWindow);
 #endif
     }
 
@@ -223,6 +226,7 @@ namespace SohGui {
 #ifdef ENABLE_REMOTE_CONTROL
         mAnchorPlayerLocationWindow = nullptr;
         mAnchorLogWindow = nullptr;
+        mAnchorTrapWindow = nullptr;
 #endif
     }
 }

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1538,6 +1538,7 @@ void DrawRemoteControlMenu() {
         static uint16_t port = CVarGetInteger("gRemote.Port", 43384);
         static std::string AnchorName = CVarGetString("gRemote.AnchorName", "");
         static std::string anchorRoomId = CVarGetString("gRemote.AnchorRoomId", "");
+        static std::string AnchorTeam = CVarGetString("gRemote.AnchorTeam", "");
         bool isFormValid = !isStringEmpty(CVarGetString("gRemote.IP", "127.0.0.1")) && port > 1024 && port < 65535 && (
             CVarGetInteger("gRemote.Scheme", GI_SCHEME_SAIL) != GI_SCHEME_ANCHOR ||
             (
@@ -1653,11 +1654,27 @@ void DrawRemoteControlMenu() {
                 LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
             }
             ImGui::Text("Room ID");
+            UIWidgets::InsertHelpHoverText(
+                "Identifier for your room that must match across all players. "
+                "Use something unique, this is basically your password."
+            );
             int flags = 0;
             if (GameInteractor::Instance->isRemoteInteractorEnabled) flags = ImGuiInputTextFlags_Password;
             ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
             if (ImGui::InputText("##gRemote.AnchorRoomId", (char*)anchorRoomId.c_str(), anchorRoomId.capacity() + 1, flags)) {
                 CVarSetString("gRemote.AnchorRoomId", anchorRoomId.c_str());
+                LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+            }
+            ImGui::Text("Team ID");
+            UIWidgets::InsertHelpHoverText(
+                "Identifier for your team. Players with matching Team IDs will share inventory and game state. "
+                "Items picked up by members of one team will not be shared with other teams.\n"
+                "\n"
+                "When joining an existing room, your inventory will be synced with anyone with a matching Team ID."
+            );
+            ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
+            if (ImGui::InputText("##gRemote.AnchorTeam", (char*)AnchorTeam.c_str(), AnchorTeam.capacity() + 1, ImGuiInputTextFlags_None)) {
+                CVarSetString("gRemote.AnchorTeam", AnchorTeam.c_str());
                 LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
             }
         }

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -101,6 +101,8 @@ static const char* imguiScaleOptions[4] = { "Small", "Normal", "Large", "X-Large
         "OHKO"
     };
     static const char* timeTravelOptions[3] = { "Disabled", "Ocarina of Time", "Any Ocarina" };
+    static const char* locationDisplayOptions[3] = { "On", "Off", "Teammates Only" };
+    static const char* teleportOptions[3] = { "On", "Off", "Teammates Only" };
 
 extern "C" SaveContext gSaveContext;
 
@@ -1684,6 +1686,14 @@ void DrawRemoteControlMenu() {
                 UIWidgets::EnhancementCheckbox("Broadcast items to all.", "gBroadcastItemsToAll");
                 UIWidgets::Tooltip("Alert everyone when an item is found, including players on opposing teams. If off, "
                                    "only teammates are alerted when they receive the item.");
+
+                ImGui::Text("Display Player Location");
+                UIWidgets::EnhancementCombobox("gLocationDisplay", locationDisplayOptions, 0);
+                UIWidgets::Tooltip("Modify which players' locations you can see");
+
+                ImGui::Text("Enable Teleport");
+                UIWidgets::EnhancementCombobox("gTeleportOptions", teleportOptions, 0);
+                UIWidgets::Tooltip("Modify who you can teleport to");
 
                 UIWidgets::PaddedEnhancementSliderInt("Teleport Cost: %d Rupees", "##gTeleportRupeeCost",
                                                       "gTeleportRupeeCost", 0, 200, "", 0, true, true, true);

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1677,10 +1677,21 @@ void DrawRemoteControlMenu() {
                 CVarSetString("gRemote.AnchorTeam", AnchorTeam.c_str());
                 LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
             }
+
+            UIWidgets::PaddedSeparator(true, true);
+
+            if (ImGui::BeginMenu("Room Settings")) {
+                UIWidgets::PaddedEnhancementSliderInt("Teleport Cost: %d Rupees", "##gTeleportRupeeCost",
+                                                      "gTeleportRupeeCost", 0, 200, "", 0, true, true, true);
+                UIWidgets::Tooltip("Rupees needed to teleport to another player.");
+                ImGui::EndMenu();
+            }
+
         }
         ImGui::EndDisabled();
 
         ImGui::Spacing();
+        UIWidgets::PaddedSeparator(false, true);
 
         if (CVarGetInteger("gRemote.Scheme", GI_SCHEME_SAIL) == GI_SCHEME_ANCHOR) {
             ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(12.0f, 6.0f));

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1688,6 +1688,18 @@ void DrawRemoteControlMenu() {
                 UIWidgets::PaddedEnhancementSliderInt("Teleport Cost: %d Rupees", "##gTeleportRupeeCost",
                                                       "gTeleportRupeeCost", 0, 200, "", 0, true, true, true);
                 UIWidgets::Tooltip("Rupees needed to teleport to another player.");
+
+                ImGui::Text("PVP Damage Multiplier");
+                UIWidgets::EnhancementCombobox("gPvpDamageMul", allPowers, 0);
+                UIWidgets::Tooltip("Modifies all sources of damage from other players\n"
+                                   "2x: Can survive all common attacks from the start of the game\n"
+                                   "4x: Dies in 1 hit to any substantial attack from the start of the game\n"
+                                   "8x: Can only survive trivial damage from the start of the game\n"
+                                   "16x: Can survive all common attacks with max health without double defense\n"
+                                   "32x: Can survive all common attacks with max health and double defense\n"
+                                   "64x: Can survive trivial damage with max health without double defense\n"
+                                   "128x: Can survive trivial damage with max health and double defense\n"
+                                   "256x: Cannot survive damage");
                 ImGui::EndMenu();
             }
 

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1429,6 +1429,7 @@ extern std::shared_ptr<ValueViewerWindow> mValueViewerWindow;
 #ifdef ENABLE_REMOTE_CONTROL
 extern std::shared_ptr<AnchorPlayerLocationWindow> mAnchorPlayerLocationWindow;
 extern std::shared_ptr<AnchorLogWindow> mAnchorLogWindow;
+extern std::shared_ptr<AnchorTrapWindow> mAnchorTrapWindow;
 #endif
 
 void DrawDeveloperToolsMenu() {
@@ -1700,6 +1701,34 @@ void DrawRemoteControlMenu() {
                                                       "gTeleportRupeeCost", 0, 200, "", 0, true, true, true);
                 UIWidgets::Tooltip("Rupees needed to teleport to another player.");
 
+                UIWidgets::PaddedSeparator(true, true);
+                if (ImGui::BeginMenu("Trap Menu Options")) {
+                    UIWidgets::PaddedEnhancementSliderInt("Cucco Cost: %d Rupees", "##gTrapMenuCuccoCost",
+                                                          "gTrapMenuCuccoCost", 0, 200, "", 50, true, true, true);
+                    UIWidgets::PaddedEnhancementSliderInt("Hands Cost: %d Rupees", "##gTrapMenuHandsCost",
+                                                          "gTrapMenuHandsCost", 0, 200, "", 20, true, true, true);
+                    UIWidgets::PaddedEnhancementSliderInt("Gibdo Cost: %d Rupees", "##gTrapMenuGibdoCost",
+                                                          "gTrapMenuGibdoCost", 0, 200, "", 99, true, true, true);
+                    UIWidgets::PaddedEnhancementSliderInt("Like Like Cost: %d Rupees", "##gTrapMenuLikeLikeCost",
+                                                          "gTrapMenuLikeLikeCost", 0, 200, "", 50, true, true, true);
+                    UIWidgets::PaddedEnhancementSliderInt("Small Knockback Cost: %d Rupees",
+                                                          "##gTrapMenuKnockback2Cost", "gTrapMenuKnockback2Cost", 0,
+                                                          200, "", 50, true, true, true);
+                    UIWidgets::PaddedEnhancementSliderInt("Large Knockback Cost: %d Rupees",
+                                                          "##gTrapMenuKnockback4Cost", "gTrapMenuKnockback4Cost", 0,
+                                                          200, "", 100, true, true, true);
+                    UIWidgets::PaddedEnhancementSliderInt("Random Wind Cost: %d Rupees", "##gTrapMenuRandWindCost",
+                                                          "gTrapMenuRandWindCost", 0, 200, "", 100, true, true, true);
+                    UIWidgets::PaddedEnhancementSliderInt("Slippery Cost: %d Rupees", "##gTrapMenuSlipperyCost",
+                                                          "gTrapMenuSlipperyCost", 0, 200, "", 50, true, true, true);
+                    UIWidgets::PaddedEnhancementSliderInt("Inverted Controls Cost: %d Rupees", "##gTrapMenuInvertedCost",
+                                                          "gTrapMenuInvertedCost", 0, 200, "", 150, true, true, true);
+                    UIWidgets::PaddedEnhancementSliderInt("Teleport Home Cost: %d Rupees", "##gTrapMenuTelehomeCost",
+                                                          "gTrapMenuTelehomeCost", 0, 200, "", 200, true, true, true);
+                    ImGui::EndMenu();
+                }
+                UIWidgets::PaddedSeparator(true, true);
+
                 ImGui::Text("PVP Damage Multiplier");
                 UIWidgets::EnhancementCombobox("gPvpDamageMul", allPowers, 0);
                 UIWidgets::Tooltip("Modifies all sources of damage from other players\n"
@@ -1756,6 +1785,17 @@ void DrawRemoteControlMenu() {
                     "buttons to change the direction the messages stack towards."
                 );
             }
+            if (mAnchorTrapWindow) {
+                if (ImGui::Button(
+                        GetWindowButtonText("Traps Menu", CVarGetInteger("gRemote.AnchorTrapWindow", 0)).c_str(),
+                        ImVec2(ImGui::GetContentRegionAvail().x - 20.0f, 0.0f))) {
+                    mAnchorTrapWindow->ToggleVisibility();
+                }
+                UIWidgets::InsertHelpHoverText("This window shows various traps you can send to your opponents.\n"
+                                               "\n"
+                                               "You can move this window around, and press the options "
+                                               "to send traps to players on opposing teams.");
+            }
             ImGui::PopStyleVar(3);
         }
 
@@ -1783,6 +1823,9 @@ void DrawRemoteControlMenu() {
                         if (CVarGetInteger("gRemote.AnchorPlayerLocationWindow", 0) && mAnchorPlayerLocationWindow) {
                             mAnchorPlayerLocationWindow->ToggleVisibility();
                         }
+                        if (CVarGetInteger("gRemote.AnchorTrapWindow", 0) && mAnchorTrapWindow) {
+                            mAnchorTrapWindow->ToggleVisibility();
+                        }
                         GameInteractorAnchor::Instance->Disable();
                         break;
                 }
@@ -1802,6 +1845,9 @@ void DrawRemoteControlMenu() {
                         }
                         if (!CVarGetInteger("gRemote.AnchorPlayerLocationWindow", 0) && mAnchorPlayerLocationWindow) {
                             mAnchorPlayerLocationWindow->ToggleVisibility();
+                        }
+                        if (!CVarGetInteger("gRemote.AnchorTrapWindow", 0) && mAnchorTrapWindow) {
+                            mAnchorTrapWindow->ToggleVisibility();
                         }
                         if (CVarGetInteger("gIceTrapTargets", ICE_TRAP_TARGETS_TEAM_ONLY) == ICE_TRAP_TARGETS_ENEMIES_ONLY) {
                             // Enable additional traps to allow ice traps to turn off for yourself.

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1681,6 +1681,10 @@ void DrawRemoteControlMenu() {
             UIWidgets::PaddedSeparator(true, true);
 
             if (ImGui::BeginMenu("Room Settings")) {
+                UIWidgets::EnhancementCheckbox("Broadcast items to all.", "gBroadcastItemsToAll");
+                UIWidgets::Tooltip("Alert everyone when an item is found, including players on opposing teams. If off, "
+                                   "only teammates are alerted when they receive the item.");
+
                 UIWidgets::PaddedEnhancementSliderInt("Teleport Cost: %d Rupees", "##gTeleportRupeeCost",
                                                       "gTeleportRupeeCost", 0, 200, "", 0, true, true, true);
                 UIWidgets::Tooltip("Rupees needed to teleport to another player.");

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -103,6 +103,7 @@ static const char* imguiScaleOptions[4] = { "Small", "Normal", "Large", "X-Large
     static const char* timeTravelOptions[3] = { "Disabled", "Ocarina of Time", "Any Ocarina" };
     static const char* locationDisplayOptions[3] = { "On", "Off", "Teammates Only" };
     static const char* teleportOptions[3] = { "On", "Off", "Teammates Only" };
+    static const char* iceTrapTargets[4] = { "Team Only", "Self Only", "Enemies Only", "All" };
 
 extern "C" SaveContext gSaveContext;
 
@@ -1710,6 +1711,14 @@ void DrawRemoteControlMenu() {
                                    "64x: Can survive trivial damage with max health without double defense\n"
                                    "128x: Can survive trivial damage with max health and double defense\n"
                                    "256x: Cannot survive damage");
+
+                ImGui::Text("Ice Trap Targets");
+                UIWidgets::EnhancementCombobox("gIceTrapTargets", iceTrapTargets, ICE_TRAP_TARGETS_TEAM_ONLY);
+                UIWidgets::Tooltip("Choose who gets affected when an ice trap is picked up.\n"
+                                   "\n"
+                                   "If Enemies Only is picked, Enhancements > Extra Modes > Additional Traps will "
+                                   "also be turned on to allow ice traps to be ignored for yourself.");
+
                 ImGui::EndMenu();
             }
 
@@ -1793,6 +1802,10 @@ void DrawRemoteControlMenu() {
                         }
                         if (!CVarGetInteger("gRemote.AnchorPlayerLocationWindow", 0) && mAnchorPlayerLocationWindow) {
                             mAnchorPlayerLocationWindow->ToggleVisibility();
+                        }
+                        if (CVarGetInteger("gIceTrapTargets", ICE_TRAP_TARGETS_TEAM_ONLY) == ICE_TRAP_TARGETS_ENEMIES_ONLY) {
+                            // Enable additional traps to allow ice traps to turn off for yourself.
+                            CVarSetInteger("gAddTraps.enabled", 1);
                         }
                         GameInteractorAnchor::Instance->Enable();
                         break;


### PR DESCRIPTION
This fork introduces teams to the Anchor build of SoH. Only players on the same team share inventory and game state, while all players still appear in the world, encouraging more PvP with players on opposing teams. Some features:

- Room settings, which are locked in by person creating the room. Anyone joining an existing room will copy those settings
- Choose whose location you can see and who you can teleport to
- PvP damage multipliers
- Ice trap behavior, which includes not affecting yourself/teammates and only enemies
- Trap menu, which lets you spend rupees to send traps to opponents. The costs of each trap can be adjusted.
![Screenshot 2024-03-16 003444](https://github.com/flee135/OOT/assets/5531989/c9978424-ad38-4234-98b2-f4eac8d698ff)
