### PR TITLE
Msg box and trap queue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 20 CACHE STRING "The C++ standard to use")
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
 
 project(Ship VERSION 8.0.3 LANGUAGES C CXX)
-set(PROJECT_BUILD_NAME "Anchor Teams v0.0.1" CACHE STRING "")
+set(PROJECT_BUILD_NAME "Anchor Teams v0.0.2" CACHE STRING "")
 set(PROJECT_TEAM "github.com/harbourmasters" CACHE STRING "")
 
 set_property(DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT soh)

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Anchor.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Anchor.cpp
@@ -12,8 +12,9 @@
 #include <soh/Enhancements/randomizer/randomizer_check_tracker.h>
 #include <soh/util.h>
 #include <nlohmann/json.hpp>
-#include <sstream>
 #include <cstring>
+#include <sstream>
+#include <queue>
 
 extern "C" {
 #include <variables.h>
@@ -286,6 +287,7 @@ std::vector<uint16_t> discoveredEntrances = {};
 std::vector<AnchorMessage> anchorMessages = {};
 uint32_t notificationId = 0;
 bool settingsCopied = false;
+std::queue<std::string> queuedTraps;
 bool randomWindOn = false;
 uint16_t randomWindTimer = 0;
 bool slipperyOn = false;
@@ -843,50 +845,19 @@ void GameInteractorAnchor::HandleRemoteJson(nlohmann::json payload) {
             return;
         }
 
-        if (payload["trapType"] == "cuccostorm") {
-            GameInteractor::RawAction::SpawnActor(ACTOR_EN_NIW, 0);
+        std::string trap = payload["trapType"];
+        // Certain traps like spawning certain enemies will be added multiple times.
+        uint8_t n = 1;
+        if (trap == "hands") {
+            n = 5;
+        } else if (trap == "gibdos") {
+            n = 4;
+        } else if (trap == "likelike") {
+            n = 4;
         }
-        if (payload["trapType"] == "hands") {
-            GameInteractor::RawAction::SpawnEnemyWithOffset(ACTOR_EN_DHA, 0);
-            GameInteractor::RawAction::SpawnEnemyWithOffset(ACTOR_EN_DHA, 0);
-            GameInteractor::RawAction::SpawnEnemyWithOffset(ACTOR_EN_DHA, 0);
-            GameInteractor::RawAction::SpawnEnemyWithOffset(ACTOR_EN_DHA, 0);
-            GameInteractor::RawAction::SpawnEnemyWithOffset(ACTOR_EN_DHA, 0);
-        }
-        if (payload["trapType"] == "gibdos") {
-            GameInteractor::RawAction::SpawnEnemyWithOffset(ACTOR_EN_RD, 32766);
-            GameInteractor::RawAction::SpawnEnemyWithOffset(ACTOR_EN_RD, 32766);
-            GameInteractor::RawAction::SpawnEnemyWithOffset(ACTOR_EN_RD, 32766);
-            GameInteractor::RawAction::SpawnEnemyWithOffset(ACTOR_EN_RD, 32766);
-        }
-        if (payload["trapType"] == "likelike") {
-            GameInteractor::RawAction::SpawnEnemyWithOffset(ACTOR_EN_RR, 0);
-            GameInteractor::RawAction::SpawnEnemyWithOffset(ACTOR_EN_RR, 0);
-            GameInteractor::RawAction::SpawnEnemyWithOffset(ACTOR_EN_RR, 0);
-            GameInteractor::RawAction::SpawnEnemyWithOffset(ACTOR_EN_RR, 0);
-        }
-        if (payload["trapType"] == "knockback2") {
-            GameInteractor::RawAction::KnockbackPlayer(2);
-        }
-        if (payload["trapType"] == "knockback4") {
-            GameInteractor::RawAction::KnockbackPlayer(4);
-        }
-        if (payload["trapType"] == "randwind") {
-            randomWindTimer = 0;
-            randomWindOn = true;
-        }
-        if (payload["trapType"] == "slippery") {
-            slipperyTimer = 0;
-            slipperyOn = true;
-            GameInteractor::State::SlipperyFloorActive = 1;
-        }
-        if (payload["trapType"] == "inverted") {
-            invertedTimer = 0;
-            invertedOn = true;
-            GameInteractor::State::ReverseControlsActive = 1;
-        }
-        if (payload["trapType"] == "telehome") {
-            GameInteractor::RawAction::TeleportPlayer(GI_TP_DEST_LINKSHOUSE);
+
+        for (int i = 0; i < n; i++) {
+            queuedTraps.push(trap);
         }
     }
     if (payload["type"] == "PLAYER_MESSAGE") {
@@ -1293,6 +1264,60 @@ void Anchor_RegisterHooks() {
         gSaveContext.playerData.damageEffect = 0;
         gSaveContext.playerData.damageValue = 0;
         gSaveContext.playerData.playerSound = 0;
+    });
+
+    // Process anything in the trap queue.
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnPlayerUpdate>([]() {
+        if (queuedTraps.empty()) {
+            return;
+        }
+
+        const std::string& trap = queuedTraps.front();
+
+        // Store result if the action returns GameInteractionEffectQueryResult.
+        GameInteractionEffectQueryResult result = GameInteractionEffectQueryResult::Possible;
+
+        if (trap == "cuccostorm") {
+            result = GameInteractor::RawAction::SpawnActor(ACTOR_EN_NIW, 0);
+        } else if (trap == "hands") {
+            result = GameInteractor::RawAction::SpawnEnemyWithOffset(ACTOR_EN_DHA, 0);
+        } else if (trap == "gibdos") {
+            result = GameInteractor::RawAction::SpawnEnemyWithOffset(ACTOR_EN_RD, 32766);
+        } else if (trap == "likelike") {
+            result = GameInteractor::RawAction::SpawnEnemyWithOffset(ACTOR_EN_RR, 0);
+        } else if (trap == "knockback2" || trap == "knockback4") {
+            Player* player = GET_PLAYER(gPlayState);
+            if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused() ||
+                player->stateFlags2 & PLAYER_STATE2_CRAWLING) {
+                result = GameInteractionEffectQueryResult::TemporarilyNotPossible;
+            } else if (trap == "knockback2") {
+                GameInteractor::RawAction::KnockbackPlayer(2);
+            } else if (trap == "knockback4") {
+                GameInteractor::RawAction::KnockbackPlayer(4);
+            }
+        } else if (trap == "randwind") {
+            randomWindTimer = 0;
+            randomWindOn = true;
+        } else if (trap == "slippery") {
+            slipperyTimer = 0;
+            slipperyOn = true;
+            GameInteractor::State::SlipperyFloorActive = 1;
+        } else if (trap == "inverted") {
+            invertedTimer = 0;
+            invertedOn = true;
+            GameInteractor::State::ReverseControlsActive = 1;
+        } else if (trap == "telehome") {
+            if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+                result = GameInteractionEffectQueryResult::TemporarilyNotPossible;
+            } else {
+                GameInteractor::RawAction::TeleportPlayer(GI_TP_DEST_LINKSHOUSE);
+            }
+        }
+
+        // If we got TemporarilyNotPossible, just leave it in the queue and try again.
+        if (result != GameInteractionEffectQueryResult::TemporarilyNotPossible) {
+            queuedTraps.pop();
+        }
     });
 
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnPlayerUpdate>([]() {


### PR DESCRIPTION
Add an input box that players can use to send messages, either to all players in the room, or to teammates only.

Refactor traps sent from the trap menu to be queued, and check the result when applying a trap. Traps will wait in the queue until they're able to be applied.