### PR TITLE
Anchor teams pvp buff

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 20 CACHE STRING "The C++ standard to use")
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
 
 project(Ship VERSION 8.0.3 LANGUAGES C CXX)
-set(PROJECT_BUILD_NAME "Anchor Teams v0.0.2" CACHE STRING "")
+set(PROJECT_BUILD_NAME "Anchor Teams v0.0.3" CACHE STRING "")
 set(PROJECT_TEAM "github.com/harbourmasters" CACHE STRING "")
 
 set_property(DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT soh)

--- a/soh/soh/Enhancements/enhancementTypes.h
+++ b/soh/soh/Enhancements/enhancementTypes.h
@@ -85,4 +85,9 @@ typedef enum {
     ICE_TRAP_TARGETS_ALL,
 } IceTrapTargets;
 
+typedef enum {
+    REFILL_WALLET,
+    REFILL_CONSUMABLES,
+} PvpBuff;
+
 #endif

--- a/soh/soh/Enhancements/enhancementTypes.h
+++ b/soh/soh/Enhancements/enhancementTypes.h
@@ -86,8 +86,10 @@ typedef enum {
 } IceTrapTargets;
 
 typedef enum {
-    REFILL_WALLET,
-    REFILL_CONSUMABLES,
+    PVP_BUFF_REFILL_WALLET,
+    PVP_BUFF_REFILL_CONSUMABLES,
+    PVP_BUFF_SPEED_BOOST,
+    PVP_BUFF_INVINCIBILITY,
 } PvpBuff;
 
 #endif

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -191,6 +191,7 @@ public:
     DEFINE_HOOK(OnActorKill, void(void* actor));
     DEFINE_HOOK(OnEnemyDefeat, void(void* actor));
     DEFINE_HOOK(OnPlayerBonk, void());
+    DEFINE_HOOK(OnGameOver, void());
     DEFINE_HOOK(OnPlayDestroy, void());
     DEFINE_HOOK(OnPlayDrawEnd, void());
 

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
@@ -82,6 +82,10 @@ void GameInteractor_ExecuteOnPlayerBonk() {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerBonk>();
 }
 
+void GameInteractor_ExecuteOnGameOverHooks() {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnGameOver>();
+}
+
 void GameInteractor_ExecuteOnPlayDestroy() {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayDestroy>();
 }

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
@@ -25,6 +25,7 @@ void GameInteractor_ExecuteOnEnemyDefeat(void* actor);
 void GameInteractor_ExecuteOnPlayerBonk();
 void GameInteractor_ExecuteOnOcarinaSongAction();
 void GameInteractor_ExecuteOnShopSlotChangeHooks(uint8_t cursorIndex, int16_t price);
+void GameInteractor_ExecuteOnGameOverHooks();
 void GameInteractor_ExecuteOnPlayDestroy();
 void GameInteractor_ExecuteOnPlayDrawEnd();
 

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1702,7 +1702,28 @@ void DrawRemoteControlMenu() {
                 UIWidgets::Tooltip("Rupees needed to teleport to another player.");
 
                 UIWidgets::PaddedSeparator(true, true);
-                if (ImGui::BeginMenu("Trap Menu Options")) {
+
+                if (ImGui::BeginMenu("PvP Buff Options")) {
+                    UIWidgets::InsertHelpHoverText(
+                        "PvP credits can be obtained when dealing the final blow to a player "
+                        "on an opposing team. Enabling a buff will add it to the PvP menu as "
+                        "an option to spend PvP credits on.");
+                    UIWidgets::EnhancementCheckbox("Refill Wallet", "gPvpBuffEnableRefillWallet", false, "",
+                                                   UIWidgets::CheckboxGraphics::Cross, true);
+                    UIWidgets::EnhancementCheckbox("Refill Consumables", "gPvpBuffEnableRefillConsumables", false, "",
+                                                   UIWidgets::CheckboxGraphics::Cross, true);
+                    UIWidgets::Tooltip("Refills sticks, nuts, bombs, arrows, and deku seeds.\n"
+                    "\n"
+                    "If chus are in logic and have been discovered, then chus will be maxed out as well.");
+                    UIWidgets::EnhancementCheckbox("Speed Boost", "gPvpBuffEnableSpeedBoost", false, "",
+                                                   UIWidgets::CheckboxGraphics::Cross, true);
+                    UIWidgets::Tooltip("Run speed boost for 1 minute.");
+                    UIWidgets::EnhancementCheckbox("Invincibility", "gPvpBuffEnableInvincibility", false, "",
+                                                   UIWidgets::CheckboxGraphics::Cross, true);
+                    UIWidgets::Tooltip("Invincibility for 1 minute.");
+                    ImGui::EndMenu();
+                }
+                if (ImGui::BeginMenu("PvP Trap Options")) {
                     UIWidgets::PaddedEnhancementSliderInt("Cucco Cost: %d Rupees", "##gTrapMenuCuccoCost",
                                                           "gTrapMenuCuccoCost", 0, 200, "", 50, true, true, true);
                     UIWidgets::PaddedEnhancementSliderInt("Hands Cost: %d Rupees", "##gTrapMenuHandsCost",
@@ -1725,16 +1746,6 @@ void DrawRemoteControlMenu() {
                                                           "gTrapMenuInvertedCost", 0, 200, "", 150, true, true, true);
                     UIWidgets::PaddedEnhancementSliderInt("Teleport Home Cost: %d Rupees", "##gTrapMenuTelehomeCost",
                                                           "gTrapMenuTelehomeCost", 0, 200, "", 200, true, true, true);
-                    ImGui::EndMenu();
-                }
-                if (ImGui::BeginMenu("PvP Buffs")) {
-                    UIWidgets::InsertHelpHoverText(
-                        "Possible buffs that you can get when dealing the final blow to another player.\n"
-                        "\n"
-                        "If everything is unchecked, no buff will be applied. If multiple are checked, a buff is "
-                        "selected at random with equal probability.");
-                    UIWidgets::EnhancementCheckbox("Refill Wallet", "gPvpBuffRefillWallet");
-                    UIWidgets::EnhancementCheckbox("Refill Consumables", "gPvpBuffRefillConsumables");
                     ImGui::EndMenu();
                 }
                 UIWidgets::PaddedSeparator(true, true);
@@ -1797,11 +1808,12 @@ void DrawRemoteControlMenu() {
             }
             if (mAnchorTrapWindow) {
                 if (ImGui::Button(
-                        GetWindowButtonText("Traps Menu", CVarGetInteger("gRemote.AnchorTrapWindow", 0)).c_str(),
+                        GetWindowButtonText("PvP Menu", CVarGetInteger("gRemote.AnchorTrapWindow", 0)).c_str(),
                         ImVec2(ImGui::GetContentRegionAvail().x - 20.0f, 0.0f))) {
                     mAnchorTrapWindow->ToggleVisibility();
                 }
-                UIWidgets::InsertHelpHoverText("This window shows various traps you can send to your opponents.\n"
+                UIWidgets::InsertHelpHoverText("This window shows various buffs you can give yourself "
+                                               "and traps you can send to your opponents.\n"
                                                "\n"
                                                "You can move this window around, and press the options "
                                                "to send traps to players on opposing teams.");

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1727,6 +1727,16 @@ void DrawRemoteControlMenu() {
                                                           "gTrapMenuTelehomeCost", 0, 200, "", 200, true, true, true);
                     ImGui::EndMenu();
                 }
+                if (ImGui::BeginMenu("PvP Buffs")) {
+                    UIWidgets::InsertHelpHoverText(
+                        "Possible buffs that you can get when dealing the final blow to another player.\n"
+                        "\n"
+                        "If everything is unchecked, no buff will be applied. If multiple are checked, a buff is "
+                        "selected at random with equal probability.");
+                    UIWidgets::EnhancementCheckbox("Refill Wallet", "gPvpBuffRefillWallet");
+                    UIWidgets::EnhancementCheckbox("Refill Consumables", "gPvpBuffRefillConsumables");
+                    ImGui::EndMenu();
+                }
                 UIWidgets::PaddedSeparator(true, true);
 
                 ImGui::Text("PVP Damage Multiplier");

--- a/soh/src/code/z_game_over.c
+++ b/soh/src/code/z_game_over.c
@@ -1,4 +1,5 @@
 #include "global.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 void GameOver_Init(PlayState* play) {
     play->gameOverCtx.state = GAMEOVER_INACTIVE;
@@ -31,6 +32,8 @@ void GameOver_Update(PlayState* play) {
             gSaveContext.timer1State = 0;
             gSaveContext.timer2State = 0;
             gSaveContext.eventInf[1] &= ~1;
+
+            GameInteractor_ExecuteOnGameOverHooks();
 
             // search inventory for spoiling items and revert if necessary
             if (!(IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_ADULT_TRADE))) {


### PR DESCRIPTION
Add hooks to recognize when one player gets a kill on another player on an opposing team, and give players credits when doing so. These can be spent in the PvP menu for buffs.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/flee135/OOT/actions/artifacts/1354663610.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/flee135/OOT/actions/artifacts/1354663611.zip)
  - [soh-linux-performance.zip](https://nightly.link/flee135/OOT/actions/artifacts/1354663613.zip)
  - [soh-mac.zip](https://nightly.link/flee135/OOT/actions/artifacts/1354663614.zip)
  - [soh-switch.zip](https://nightly.link/flee135/OOT/actions/artifacts/1354663615.zip)
  - [soh-wiiu.zip](https://nightly.link/flee135/OOT/actions/artifacts/1354663617.zip)
  - [soh-windows.zip](https://nightly.link/flee135/OOT/actions/artifacts/1354663618.zip)
<!--- section:artifacts:end -->